### PR TITLE
Fix for issue with shared Sainudiin models

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -16,7 +16,7 @@
   <property name="srcBeast2" location="${beast2path}/src" />
   <property name="beast2classpath" location="${beast2path}/build" />
   <property name="Add_on_dir" value="${release_dir}/add-on" />
-  <property name="version" value="0.1.1" />
+  <property name="version" value="0.1.2" />
 
     <import file="${beast2path}/build.xml" />
 

--- a/src/beast/evolution/substitutionmodel/Sainudiin.java
+++ b/src/beast/evolution/substitutionmodel/Sainudiin.java
@@ -314,22 +314,24 @@ public class Sainudiin extends SubstitutionModel.Base {
   // Copied from GeneralSubstitutionModel.java
   @Override
   public void store() {
-    storedUpdateMatrix = updateMatrix;
-    if( eigenDecomposition != null ) {
-      storedEigenDecomposition = eigenDecomposition.copy();
-    }
+//    storedUpdateMatrix = updateMatrix;
+//    if( eigenDecomposition != null ) {
+//      storedEigenDecomposition = eigenDecomposition.copy();
+//    }
+	  updateMatrix = true;
     super.store();
   }
 
   // Copied from GeneralSubstitutionModel.java
   @Override
   public void restore() {
-    updateMatrix = storedUpdateMatrix;
-    if( storedEigenDecomposition != null ) {
-      EigenDecomposition tmp = storedEigenDecomposition;
-      storedEigenDecomposition = eigenDecomposition;
-      eigenDecomposition = tmp;
-    }
+//    updateMatrix = storedUpdateMatrix;
+//    if( storedEigenDecomposition != null ) {
+//      EigenDecomposition tmp = storedEigenDecomposition;
+//      storedEigenDecomposition = eigenDecomposition;
+//      eigenDecomposition = tmp;
+//    }
+	  updateMatrix = true;
     super.restore();
   }
 

--- a/version.xml
+++ b/version.xml
@@ -1,3 +1,3 @@
-<addon name='BEASTvntr' version='0.1.1'>
-  <depends on='beast2' atleast='2.4.3'/>
-</addon>
+<package name='BEASTvntr' version='0.1.2'>
+  <depends on='beast2' atleast='2.5.0'/>
+</package>


### PR DESCRIPTION
Hi Arjun,

I put in a fix for a problem that caused incorrectly calculated likelihood errors when there are multiple trees using the same Sainudiin model. It is slightly less efficient, since the Eigen decomposition is performed more often, but at least it results in the same treelikelihood calculations when the substitution model is shared. I put in a release for BEAST v2.5.0 on my fork -- people are waiting for this fix -- but think it is better to have it on your site. Let me know if/when you done so and I change the link that BEAUti uses to find the package.

Cheers, Remco